### PR TITLE
Commands & Queenstown message

### DIFF
--- a/kr/stringCommon.xml
+++ b/kr/stringCommon.xml
@@ -3297,11 +3297,27 @@
   <key id="s_pet_cant_summon_state_play_instrument" value="Can summon a pet during play."/>
   <key id="s_pet_cant_summon_state_fishing" value="Fishing is not able to summon the pet."/>
 
-  <key id="s_usercommanddescription_user" value="[Chat commands] World talk : /w, /world, /Fucking, /In January, /World, /World loudspeaker channels dialog : /c, /channel, /ㅊ, /Chapman, /Channel, /Channel loudspeaker area dialog : /s, /space, /That, /, /Local party conversation : /p, /party, /ㅔ, /Wave, /Party Guild dialog : /g, /guild, /Heh, /Gil, /Guild whisper : /r, /It shall come to pass, /Ear, /Ear horse, /A whisper, /whisper - [How do I use a whisper] /Whisper character names say party invites : /Party invitation, /partyinvite, /pinvite - [Party invites how to use] /Party invites character names party withdrawal : /Party opt-out, /partyleave, /pleave Guild invite : /Guild invite /guildinvite, /ginvite - [How do I use the Guild invite] /Guild invite character names Mei view search : /Search, /search - [How do I use the view search mate] /To move the channel search queries : /Shift channels - [How to move the channel] /The numbers help shift channels : /h, /help, /? "/>
-
-  <key id="s_timeevent_common_1" value="Loco! Amherst and the cave of the runes on live!"/>
-  <key id="s_timeevent_common_4" value="From Queenstown event is in progress."/>
-  <key id="s_timeevent_common_7" value="From Queenstown event is in progress."/>
+  <key id="s_usercommanddescription_user" value="[Chat Commands]
+World Chat : /w, /world, /ㅈ, /월, /월드, /월드확성기
+Channel Chat : /c, /channel, /ㅊ, /채, /채널, /채널확성기
+Area Chat : /s, /space, /ㄴ, /지, /지역
+Party Chat : /p, /party, /ㅔ, /파, /파티
+Guild Chat : /g, /guild, /ㅎ, /길, /길드
+Whisper : /r, /ㄱ, /귓, /귓말, /귓속말, /whisper
+- [How to Whisper] /r Username Text
+Party Invite : /파티초대, /partyinvite, /pinvite
+- [How to Party Invite] /pinvite Username
+Party Leave : /파티탈퇴, /partyleave, /pleave
+Guild Invite : /길드초대, /guildinvite, /ginvite
+- [How to Guild Invite] /ginvite Username
+Maview Search : /검색, /search
+- [How to Maview Search] /search Keyword
+Switch Channel : /채널이동
+- [How to Switch Channels] /채널이동
+  
+  <key id="s_timeevent_common_1" value="Let's play together! Come to the Cave of Runes in Amherst!"/>
+  <key id="s_timeevent_common_4" value="Event in Queenstown is in progress."/>
+  <key id="s_timeevent_common_7" value="Event in Queenstown is in progress."/>
   
   <key id="s_timestring_am" value="AM"/>
   <key id="s_timestring_pm" value="PM"/>

--- a/kr/stringCommon.xml
+++ b/kr/stringCommon.xml
@@ -3313,7 +3313,7 @@ Guild Invite : /길드초대, /guildinvite, /ginvite
 Maview Search : /검색, /search
 - [How to Maview Search] /search Keyword
 Switch Channel : /채널이동
-- [How to Switch Channels] /채널이동
+- [How to Switch Channels] /채널이동"/>
   
   <key id="s_timeevent_common_1" value="Let's play together! Come to the Cave of Runes in Amherst!"/>
   <key id="s_timeevent_common_4" value="Event in Queenstown is in progress."/>


### PR DESCRIPTION
I don't know if the korean commands should be left there or not. Translating commands is pointless. So it's either we keep the commands Korean or remove them from being displayed.
